### PR TITLE
Rebrand Project to Festabook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Facebook App
+# Festabook
 
-A web-based [Facebook](https://www.facebook.com/) clone built using [React](https://react.dev/).
+A secret project, hiding in plain sight.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/react.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Facebook App</title>
+    <title>Festabook</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "facebook-app",
+  "name": "festabook",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This pull request resolves #47 by rebranding the project from `facebook-app` to `festabook`.