### PR TITLE
Remove Dependabot Configuration for App Directory

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,12 +16,3 @@ updates:
       prefix: chore
     labels: []
     versioning-strategy: increase
-
-  - package-ecosystem: npm
-    directory: /app
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: chore
-    labels: []
-    versioning-strategy: increase


### PR DESCRIPTION
This pull request resolves #67 by removing the Dependabot configuration for the `app` directory.