### PR TITLE
Call TypeScript for Type Checking Without the No Emit Option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm --recursive exec eslint
 
       - name: Check Types
-        run: pnpm --recursive exec tsc --noEmit
+        run: pnpm --recursive exec tsc
 
       - name: Test Project
         run: pnpm --recursive test

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -18,7 +18,7 @@ pre-commit:
       run: pnpm --recursive exec eslint --fix
 
     - name: check types
-      run: pnpm --recursive exec tsc --noEmit
+      run: pnpm --recursive exec tsc
 
     - name: check diff
       run: git diff --exit-code pnpm-lock.yaml {staged_files}


### PR DESCRIPTION
This pull request resolves #75 by omitting the `--noEmit` option when calling `tsc` in the Lefthook configuration and the Build CI workflow.