### PR TITLE
Reorder Steps for Building and Testing the Project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Check Types
+        run: pnpm --recursive exec tsc
+
+      - name: Test Project
+        run: pnpm --recursive test
+
       - name: Check Formatting
         run: |
           pnpm prettier --check .
@@ -25,12 +31,6 @@ jobs:
 
       - name: Check Lint
         run: pnpm --recursive exec eslint
-
-      - name: Check Types
-        run: pnpm --recursive exec tsc
-
-      - name: Test Project
-        run: pnpm --recursive test
 
       - name: Build Project
         run: |

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -4,6 +4,9 @@ pre-commit:
     - name: install dependencies
       run: pnpm install
 
+    - name: check types
+      run: pnpm --recursive exec tsc
+
     - name: fix formatting
       group:
         parallel: true
@@ -16,9 +19,6 @@ pre-commit:
 
     - name: fix lint
       run: pnpm --recursive exec eslint --fix
-
-    - name: check types
-      run: pnpm --recursive exec tsc
 
     - name: check diff
       run: git diff --exit-code pnpm-lock.yaml {staged_files}


### PR DESCRIPTION
This pull request resolves #77 by reordering the steps for building and testing the project in the CI workflow and pre-commit hook. The steps are now ordered so that type checks and tests are performed before formatting and linting.