### PR TITLE
Utilize Valibot to Handle Type Checks in Shared Schema

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^19.1.0",
     "react-intersection-observer": "^9.16.0",
     "react-page-visibility": "^7.0.0",
-    "shared": "workspace:*"
+    "shared": "workspace:*",
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/app/src/components/post/Post.tsx
+++ b/app/src/components/post/Post.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import type { PostData } from "shared";
+import type { PostSchema } from "shared";
 import CommentIcon from "./assets/comment-icon.png";
 import LikeIcon from "./assets/like-icon.png";
 import LikeSolidIcon from "./assets/like-solid-icon.png";
@@ -13,7 +13,7 @@ import PrivacyIcon from "./components/PrivacyIcon";
 import "./Post.css";
 
 export interface PostProps {
-  post: PostData;
+  post: PostSchema;
 }
 
 const Post: React.FC<PostProps> = ({ post }) => {

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -1,13 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import type { PostData } from "shared";
+import { postSchema } from "shared";
+import * as v from "valibot";
 import Post from "./components/post/Post";
 import "./index.css";
 
 const root = document.getElementById("root");
 if (root) {
   const res = await fetch("/api/posts");
-  const posts = (await res.json()) as PostData[];
+  const posts = v.parse(v.array(postSchema), await res.json());
 
   createRoot(root).render(
     <StrictMode>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       shared:
         specifier: workspace:*
         version: link:../shared
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.31.0
@@ -129,6 +132,10 @@ importers:
         version: 8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
 
   shared:
+    dependencies:
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.31.0
@@ -2190,6 +2197,14 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite-node@3.2.3:
     resolution: {integrity: sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==}
@@ -4569,6 +4584,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   vite-node@3.2.3(@types/node@24.0.13)(jiti@2.4.2):
     dependencies:

--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -1,8 +1,8 @@
 import { FastifyInstance } from "fastify";
-import type { PostData } from "shared";
+import type { PostSchema } from "shared";
 
 export default function (fastify: FastifyInstance) {
-  fastify.get("/api/posts", (): PostData[] => {
+  fastify.get("/api/posts", (): PostSchema[] => {
     const amiraHassan = {
       name: "Amira Hasan",
       avatar:

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "dependencies": {
+    "valibot": "^1.1.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
     "@tsconfig/node24": "^24.0.1",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,11 +1,15 @@
-export interface PostData {
-  author: {
-    name: string;
-    avatar: string;
-  };
-  caption?: string;
-  image?: string;
-  video?: string;
-  reactions?: number;
-  date: string;
-}
+import * as v from "valibot";
+
+export const postSchema = v.object({
+  author: v.object({
+    name: v.string(),
+    avatar: v.string(),
+  }),
+  caption: v.optional(v.string()),
+  image: v.optional(v.string()),
+  video: v.optional(v.string()),
+  reactions: v.optional(v.number()),
+  date: v.string(),
+});
+
+export type PostSchema = v.InferInput<typeof postSchema>;


### PR DESCRIPTION
This pull request resolves #79 by utilizing [Valibot](https://valibot.dev/) to handle type checks in the shared schema.