### PR TITLE
Add Route to Serve Static Files for Backend Server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,17 @@
-import Fastify from "fastify";
 import fastifyHttpProxy from "@fastify/http-proxy";
 import fastifyStatic from "@fastify/static";
+import Fastify from "fastify";
+import path from "node:path";
 import apiRoute from "./api.js";
 
 const fastify = Fastify({ logger: true });
 
 fastify.register(apiRoute);
+
+fastify.register(fastifyStatic, {
+  root: path.resolve("data/static"),
+  prefix: "/static",
+});
 
 if (process.env.APP_DIST_DIR) {
   fastify.register(fastifyStatic, {


### PR DESCRIPTION
This pull request resolves #85 by adding a new `/static` route to the backend server for serving static files from the `data/static` directory.