### PR TITLE
Fix Video Mute Button Not Showing on iOS

### DIFF
--- a/app/src/components/post/components/PostVideoContent.css
+++ b/app/src/components/post/components/PostVideoContent.css
@@ -14,18 +14,19 @@
 .post-video-mute-button {
   display: flex;
   position: absolute;
-  right: 2px;
-  bottom: 15px;
+  right: 7px;
+  bottom: 20px;
   justify-content: center;
   align-items: center;
   cursor: pointer;
   border: none;
   background: none;
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
 }
 
 .post-video-mute-icon {
+  position: absolute;
   width: 30px;
   height: 30px;
   fill: #fffeff;

--- a/app/src/components/post/components/PostVideoContent.css
+++ b/app/src/components/post/components/PostVideoContent.css
@@ -26,6 +26,8 @@
 }
 
 .post-video-mute-icon {
+  width: 30px;
+  height: 30px;
   fill: #fffeff;
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }


### PR DESCRIPTION
This pull request resolves #87 by fixing the video mute button icon not showing on iOS by specifying the icon's size. These changes also address an issue where the video mute button icon did not have a consistent size across platforms due to limitations of the button element.
