### PR TITLE
Fix Conflicting Static File Serving in Backend Server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,6 +17,7 @@ if (process.env.APP_DIST_DIR) {
   fastify.register(fastifyStatic, {
     root: process.env.APP_DIST_DIR,
     prefix: "/",
+    decorateReply: false,
   });
 }
 


### PR DESCRIPTION
This pull request resolves #91 by setting `decorateReply` to `false` on the subsequent registration of `@fastify/static`.
