### PR TITLE
Remove Unused Base Path Configuration in Client App

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,14 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-let base: string | undefined;
-if (process.env.GITHUB_REPOSITORY) {
-  base = process.env.GITHUB_REPOSITORY.slice(
-    process.env.GITHUB_REPOSITORY.indexOf("/"),
-  );
-}
-
 export default defineConfig({
-  base,
   plugins: [react()],
 });


### PR DESCRIPTION
This pull request resolves #94 by removing the unused base path configuration in the `vite.config.ts` file.