### PR TITLE
Add Support for Specifying Host and Port for the Backend Server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,7 +29,10 @@ if (process.env.APP_DEV_UPSTREAM) {
 }
 
 try {
-  await fastify.listen({ port: 3000 });
+  await fastify.listen({
+    host: process.env.HOST,
+    port: parseInt(process.env.PORT ?? "3000"),
+  });
 } catch (err) {
   fastify.log.error(err);
   process.exitCode = 1;


### PR DESCRIPTION
This pull request resolves #98 by adding support for specifying the host and port of the backend server using the `HOST` and `PORT` environment variables, respectively.
