### PR TITLE
Modify Admin Page to List All Users and Posts

### DIFF
--- a/app/src/admin/AdminDashboard.css
+++ b/app/src/admin/AdminDashboard.css
@@ -15,3 +15,15 @@
   color: black;
   font-size: 16px;
 }
+
+.admin-card {
+  cursor: pointer;
+  margin: 0 4px;
+  border: none;
+  border-radius: 8px;
+  background-color: white;
+  padding: 8px;
+  min-height: 30px;
+  color: black;
+  font-size: 12px;
+}

--- a/app/src/admin/AdminDashboard.css
+++ b/app/src/admin/AdminDashboard.css
@@ -23,7 +23,7 @@
   border-radius: 8px;
   background-color: white;
   padding: 8px;
-  min-height: 30px;
+  height: auto;
   color: black;
   font-size: 12px;
 }

--- a/app/src/admin/AdminDashboard.tsx
+++ b/app/src/admin/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import Timeline from "../timeline/Timeline";
+import UsersPage from "./pages/UsersPage";
 import "./AdminDashboard.css";
 
 type Page = "main" | "users" | "posts";
@@ -97,14 +98,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
       );
 
     case "users":
-      return (
-        <>
-          <h1 className="admin-title">Users</h1>
-          <button className="admin-button" onClick={openMainPage}>
-            Back
-          </button>
-        </>
-      );
+      return <UsersPage adminSecret={adminSecret} onBack={openMainPage} />;
 
     case "posts":
       return (

--- a/app/src/admin/AdminDashboard.tsx
+++ b/app/src/admin/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import Timeline from "../timeline/Timeline";
+import PostsPage from "./pages/PostsPage";
 import UsersPage from "./pages/UsersPage";
 import "./AdminDashboard.css";
 
@@ -101,14 +102,7 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
       return <UsersPage adminSecret={adminSecret} onBack={openMainPage} />;
 
     case "posts":
-      return (
-        <>
-          <h1 className="admin-title">Posts</h1>
-          <button className="admin-button" onClick={openMainPage}>
-            Back
-          </button>
-        </>
-      );
+      return <PostsPage adminSecret={adminSecret} onBack={openMainPage} />;
   }
 };
 

--- a/app/src/admin/AdminDashboard.tsx
+++ b/app/src/admin/AdminDashboard.tsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import Timeline from "../timeline/Timeline";
 import "./AdminDashboard.css";
 
+type Page = "main" | "users" | "posts";
+
 export interface AdminDashboardProps {
   adminSecret: string;
   onAdminSecretInvalid: () => void;
@@ -33,12 +35,25 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
   });
 
   const [showDashboard, setShowDashboard] = useState<boolean>(true);
+  const [page, setPage] = useState<Page>("main");
 
   if (!isSecretVerified) return null;
 
-  const openDashboard = () => {
-    setShowDashboard(true);
-  };
+  if (!showDashboard) {
+    const openDashboard = () => {
+      setShowDashboard(true);
+    };
+
+    return (
+      <>
+        <h1 className="admin-title">Timeline</h1>
+        <button className="admin-button" onClick={openDashboard}>
+          Admin Dashboard
+        </button>
+        <Timeline />
+      </>
+    );
+  }
 
   const closeDashboard = () => {
     setShowDashboard(false);
@@ -49,25 +64,58 @@ const AdminDashboard: React.FC<AdminDashboardProps> = ({
     window.history.replaceState({}, "", window.location.pathname);
   };
 
-  return showDashboard ? (
-    <>
-      <h1 className="admin-title">Admin Dashboard</h1>
-      <button className="admin-button" onClick={closeDashboard}>
-        Timeline
-      </button>
-      <button className="admin-button" onClick={exitDashboard}>
-        Exit
-      </button>
-    </>
-  ) : (
-    <>
-      <h1 className="admin-title">Timeline</h1>
-      <button className="admin-button" onClick={openDashboard}>
-        Admin Dashboard
-      </button>
-      <Timeline />
-    </>
-  );
+  const openMainPage = () => {
+    setPage("main");
+  };
+
+  const openUsersPage = () => {
+    setPage("users");
+  };
+
+  const openPostsPage = () => {
+    setPage("posts");
+  };
+
+  switch (page) {
+    case "main":
+      return (
+        <>
+          <h1 className="admin-title">Admin Dashboard</h1>
+          <button className="admin-button" onClick={closeDashboard}>
+            Timeline
+          </button>
+          <button className="admin-button" onClick={openUsersPage}>
+            Users
+          </button>
+          <button className="admin-button" onClick={openPostsPage}>
+            Posts
+          </button>
+          <button className="admin-button" onClick={exitDashboard}>
+            Exit
+          </button>
+        </>
+      );
+
+    case "users":
+      return (
+        <>
+          <h1 className="admin-title">Users</h1>
+          <button className="admin-button" onClick={openMainPage}>
+            Back
+          </button>
+        </>
+      );
+
+    case "posts":
+      return (
+        <>
+          <h1 className="admin-title">Posts</h1>
+          <button className="admin-button" onClick={openMainPage}>
+            Back
+          </button>
+        </>
+      );
+  }
 };
 
 export default AdminDashboard;

--- a/app/src/admin/pages/PostsPage.tsx
+++ b/app/src/admin/pages/PostsPage.tsx
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+import React from "react";
+import { rawPostsSchema } from "shared";
+import * as v from "valibot";
+
+export interface PostsPageProps {
+  adminSecret: string;
+  onBack: () => void;
+}
+
+const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
+  const { data: posts } = useQuery({
+    queryKey: ["admin/posts", adminSecret],
+    queryFn: async () => {
+      try {
+        const res = await fetch("/api/admin/posts", {
+          headers: { "admin-secret": adminSecret },
+        });
+        if (!res.ok) throw new Error(res.statusText);
+        return v.parse(rawPostsSchema, await res.json());
+      } catch (err) {
+        console.error("Failed to fetch posts:", err);
+        throw err;
+      }
+    },
+    initialData: [],
+  });
+
+  return (
+    <>
+      <h1 className="admin-title">Posts</h1>
+      <button className="admin-button" onClick={onBack}>
+        Back
+      </button>
+      {posts.map(({ id, authorName, caption, image, video, reactions }) => (
+        <div key={id} className="admin-card">
+          ID: {id}
+          <br />
+          Author: {authorName}
+          <br />
+          Caption: {caption ?? "_"}
+          <br />
+          Image: {image ?? "_"}
+          <br />
+          Video: {video ?? "_"}
+          <br />
+          Reactions: {reactions}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default PostsPage;

--- a/app/src/admin/pages/UsersPage.tsx
+++ b/app/src/admin/pages/UsersPage.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import React from "react";
+import { rawUsersSchema } from "shared";
+import * as v from "valibot";
+
+export interface UsersPageProps {
+  adminSecret: string;
+  onBack: () => void;
+}
+
+const UsersPage: React.FC<UsersPageProps> = ({ adminSecret, onBack }) => {
+  const { data: users } = useQuery({
+    queryKey: ["admin/users", adminSecret],
+    queryFn: async () => {
+      try {
+        const res = await fetch("/api/admin/users", {
+          headers: { "admin-secret": adminSecret },
+        });
+        if (!res.ok) throw new Error(res.statusText);
+        return v.parse(rawUsersSchema, await res.json());
+      } catch (err) {
+        console.error("Failed to fetch users:", err);
+        throw err;
+      }
+    },
+    initialData: [],
+  });
+
+  return (
+    <>
+      <h1 className="admin-title">Users</h1>
+      <button className="admin-button" onClick={onBack}>
+        Back
+      </button>
+      {users.map(({ id, name, avatar }) => (
+        <div key={id} className="admin-card">
+          ID: {id}
+          <br />
+          Name: {name}
+          <br />
+          Avatar: {avatar}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default UsersPage;

--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest } from "fastify";
 import httpErrors from "http-errors";
-import { RawUserSchema } from "shared";
+import { RawPostSchema, RawUserSchema } from "shared";
 import { db } from "../db.js";
 
 export default function adminApiRoute(fastify: FastifyInstance) {
@@ -19,5 +19,22 @@ export default function adminApiRoute(fastify: FastifyInstance) {
   fastify.get("/api/admin/users", async (request): Promise<RawUserSchema[]> => {
     assertAdminSecret(request);
     return db.selectFrom("authors").select(["id", "name", "avatar"]).execute();
+  });
+
+  fastify.get("/api/admin/posts", async (request): Promise<RawPostSchema[]> => {
+    assertAdminSecret(request);
+    return db
+      .selectFrom("posts")
+      .innerJoin("authors", "posts.author_id", "authors.id")
+      .select([
+        "posts.id",
+        "authors.name as authorName",
+        "posts.caption",
+        "posts.image",
+        "posts.video",
+        "posts.reactions",
+        "posts.date",
+      ])
+      .execute();
   });
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./schemas/admin.js";
 export * from "./schemas/posts.js";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,15 +1,1 @@
-import * as v from "valibot";
-
-export const postSchema = v.object({
-  author: v.object({
-    name: v.string(),
-    avatar: v.string(),
-  }),
-  caption: v.nullable(v.string()),
-  image: v.nullable(v.string()),
-  video: v.nullable(v.string()),
-  reactions: v.number(),
-  date: v.string(),
-});
-
-export type PostSchema = v.InferInput<typeof postSchema>;
+export * from "./schemas/posts.js";

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -1,0 +1,11 @@
+import * as v from "valibot";
+
+export const rawUserSchema = v.object({
+  id: v.number(),
+  name: v.string(),
+  avatar: v.string(),
+});
+
+export const rawUsersSchema = v.array(rawUserSchema);
+
+export type RawUserSchema = v.InferInput<typeof rawUserSchema>;

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -9,3 +9,17 @@ export const rawUserSchema = v.object({
 export const rawUsersSchema = v.array(rawUserSchema);
 
 export type RawUserSchema = v.InferInput<typeof rawUserSchema>;
+
+export const rawPostSchema = v.object({
+  id: v.number(),
+  authorName: v.string(),
+  caption: v.nullable(v.string()),
+  image: v.nullable(v.string()),
+  video: v.nullable(v.string()),
+  reactions: v.number(),
+  date: v.string(),
+});
+
+export const rawPostsSchema = v.array(rawPostSchema);
+
+export type RawPostSchema = v.InferInput<typeof rawPostSchema>;

--- a/shared/src/schemas/posts.ts
+++ b/shared/src/schemas/posts.ts
@@ -1,0 +1,15 @@
+import * as v from "valibot";
+
+export const postSchema = v.object({
+  author: v.object({
+    name: v.string(),
+    avatar: v.string(),
+  }),
+  caption: v.nullable(v.string()),
+  image: v.nullable(v.string()),
+  video: v.nullable(v.string()),
+  reactions: v.number(),
+  date: v.string(),
+});
+
+export type PostSchema = v.InferInput<typeof postSchema>;


### PR DESCRIPTION
This pull request resolves #100 by adding users and posts pages to the admin page in the client app. Both the users and posts pages are used to list all users and posts registered on the backend server.