### PR TITLE
Modify Backend Server to Load Dotenv Files

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       better-sqlite3:
         specifier: ^12.2.0
         version: 12.2.0
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.2.0
       fastify:
         specifier: ^5.4.0
         version: 5.4.0
@@ -1113,6 +1116,10 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dotenv@17.2.0:
+    resolution: {integrity: sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3452,6 +3459,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dotenv@17.2.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "@fastify/http-proxy": "^11.3.0",
     "@fastify/static": "^8.2.0",
     "better-sqlite3": "^12.2.0",
+    "dotenv": "^17.2.0",
     "fastify": "^5.4.0",
     "http-errors": "^2.0.0",
     "kysely": "^0.28.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import fastifyHttpProxy from "@fastify/http-proxy";
 import fastifyStatic from "@fastify/static";
+import "dotenv/config";
 import Fastify from "fastify";
 import path from "node:path";
 import adminApiRoute from "./api/admin.js";


### PR DESCRIPTION
This pull request resolves #110 by modifying the backend server to load `.env` files at start.