### PR TITLE
Merge Video and Image in Posts into a Single Media Field

### DIFF
--- a/app/src/admin/pages/PostsPage.tsx
+++ b/app/src/admin/pages/PostsPage.tsx
@@ -31,7 +31,7 @@ const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
       <button className="admin-button" onClick={onBack}>
         Back
       </button>
-      {posts.map(({ id, authorName, caption, image, video, reactions }) => (
+      {posts.map(({ id, authorName, caption, media, reactions }) => (
         <div key={id} className="admin-card">
           ID: {id}
           <br />
@@ -39,9 +39,7 @@ const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
           <br />
           Caption: {caption ?? "_"}
           <br />
-          Image: {image ?? "_"}
-          <br />
-          Video: {video ?? "_"}
+          Media: {media ?? "_"}
           <br />
           Reactions: {reactions}
         </div>

--- a/app/src/timeline/post/Post.tsx
+++ b/app/src/timeline/post/Post.tsx
@@ -25,6 +25,8 @@ const Post: React.FC<PostProps> = ({ post }) => {
     setIsLiked(!isLiked);
   };
 
+  const hasImageMedia = post.media && !/.(mp4|webm)$/.test(post.media);
+
   return (
     <div className="post">
       <div className="post-header">
@@ -54,18 +56,20 @@ const Post: React.FC<PostProps> = ({ post }) => {
         <div
           className="post-caption"
           style={{
-            marginBottom: !post.image && reactions > 0 ? "2px" : "12px",
+            marginBottom: !hasImageMedia && reactions > 0 ? "2px" : "12px",
           }}
         >
           {post.caption}
         </div>
       )}
-      {post.image && (
-        <div className="post-image">
-          <img src={post.image} />
-        </div>
-      )}
-      {post.video && <PostVideoContent video={post.video} />}
+      {post.media &&
+        (hasImageMedia ? (
+          <div className="post-image">
+            <img src={post.media} />
+          </div>
+        ) : (
+          <PostVideoContent video={post.media} />
+        ))}
       <div className="post-footer">
         {reactions > 0 && (
           <div className="post-interactions">

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -8,8 +8,7 @@ CREATE TABLE posts (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   author_id INTEGER NOT NULL,
   caption TEXT,
-  image TEXT,
-  video TEXT,
+  media TEXT,
   reactions INTEGER DEFAULT 0,
   date TEXT NOT NULL,
   FOREIGN KEY (author_id) REFERENCES authors(id)

--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -30,8 +30,7 @@ export default function adminApiRoute(fastify: FastifyInstance) {
         "posts.id",
         "authors.name as authorName",
         "posts.caption",
-        "posts.image",
-        "posts.video",
+        "posts.media",
         "posts.reactions",
         "posts.date",
       ])

--- a/server/src/api/posts.ts
+++ b/server/src/api/posts.ts
@@ -11,8 +11,7 @@ export default function postsApiRoute(fastify: FastifyInstance) {
         "authors.name as author_name",
         "authors.avatar as author_avatar",
         "posts.caption",
-        "posts.image",
-        "posts.video",
+        "posts.media",
         "posts.reactions",
         "posts.date",
       ])
@@ -24,8 +23,7 @@ export default function postsApiRoute(fastify: FastifyInstance) {
         avatar: row.author_avatar,
       },
       caption: row.caption,
-      image: row.image,
-      video: row.video,
+      media: row.media,
       reactions: row.reactions,
       date: row.date,
     }));

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -11,8 +11,7 @@ interface Database {
     id: Generated<number>;
     author_id: number;
     caption: Nullable<string>;
-    image: Nullable<string>;
-    video: Nullable<string>;
+    media: Nullable<string>;
     reactions: Generated<number>;
     date: string;
   };

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -18,8 +18,7 @@ const rawPostSchema = v.object({
   id: v.number(),
   authorName: v.string(),
   caption: v.nullable(v.string()),
-  image: v.nullable(v.string()),
-  video: v.nullable(v.string()),
+  media: v.nullable(v.string()),
   reactions: v.number(),
   date: v.string(),
 });

--- a/shared/src/schemas/posts.ts
+++ b/shared/src/schemas/posts.ts
@@ -6,8 +6,7 @@ const postSchema = v.object({
     avatar: v.string(),
   }),
   caption: v.nullable(v.string()),
-  image: v.nullable(v.string()),
-  video: v.nullable(v.string()),
+  media: v.nullable(v.string()),
   reactions: v.number(),
   date: v.string(),
 });


### PR DESCRIPTION
This pull request resolves #112 by modifying the backend server to merge the `video` and `image` fields in the `posts` table into a single `media` field.