### PR TITLE
Add Support for Updating Posts in the Admin Page

### DIFF
--- a/app/src/admin/posts/PostDetailsPage.tsx
+++ b/app/src/admin/posts/PostDetailsPage.tsx
@@ -1,15 +1,97 @@
+import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
+import { parseAdminPostDetails, type AdminSubmitPostInput } from "shared";
+import { SubmitPostForm } from "./SubmitPostForm";
 
 type Page = "main" | "confirm-delete";
 
-export interface ConfirmDeletePostPageProps {
+interface MainPageProps {
+  id: number;
+  adminSecret: string;
+  onBack: () => void;
+  onDelete: () => void;
+}
+
+const MainPage: React.FC<MainPageProps> = ({
+  id,
+  adminSecret,
+  onBack,
+  onDelete,
+}) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const { data: post } = useQuery({
+    queryKey: ["admin/posts", id, adminSecret],
+    queryFn: async () => {
+      try {
+        const res = await fetch(`/api/admin/posts/${id.toFixed()}`, {
+          headers: { "admin-secret": adminSecret },
+        });
+        if (!res.ok) throw new Error(res.statusText);
+        return parseAdminPostDetails(await res.json());
+      } catch (err) {
+        console.error("Failed to fetch posts:", err);
+        throw err;
+      }
+    },
+    initialData: null,
+  });
+
+  const updatePost = async (post: AdminSubmitPostInput) => {
+    setIsUpdating(true);
+    try {
+      const res = await fetch(`/api/admin/posts/${id.toFixed()}`, {
+        method: "PUT",
+        headers: {
+          "admin-secret": adminSecret,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(post),
+      });
+      if (!res.ok) throw new Error(res.statusText);
+    } catch (err) {
+      console.error("Failed to update post:", err);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <>
+      <h1 className="admin-title">Post {id}</h1>
+      <button className="admin-button" disabled={isUpdating} onClick={onBack}>
+        Back
+      </button>
+      <SubmitPostForm
+        adminSecret={adminSecret}
+        initialAuthorId={post?.authorId}
+        initialTimestamp={post?.timestamp}
+        initialCaption={post?.caption}
+        initialReactions={post?.reactions}
+        disabled={!post || isUpdating}
+        onSubmit={(post) => void updatePost(post)}
+      >
+        {isUpdating ? "Updating Post..." : "Update Post"}
+      </SubmitPostForm>
+      <button
+        className="admin-button"
+        disabled={!post || isUpdating}
+        onClick={onDelete}
+      >
+        Delete Post
+      </button>
+    </>
+  );
+};
+
+interface ConfirmDeletePageProps {
   id: number;
   adminSecret: string;
   onCancel: () => void;
   onDelete: () => void;
 }
 
-const ConfirmDeletePostPage: React.FC<ConfirmDeletePostPageProps> = ({
+const ConfirmDeletePage: React.FC<ConfirmDeletePageProps> = ({
   id,
   adminSecret,
   onCancel,
@@ -66,25 +148,19 @@ const PostDetailsPage: React.FC<PostDetailsPageProps> = ({
   switch (page) {
     case "main":
       return (
-        <>
-          <h1 className="admin-title">Post {id}</h1>
-          <button className="admin-button" onClick={onBack}>
-            Back
-          </button>
-          <button
-            className="admin-button"
-            onClick={() => {
-              setPage("confirm-delete");
-            }}
-          >
-            Delete Post
-          </button>
-        </>
+        <MainPage
+          id={id}
+          adminSecret={adminSecret}
+          onBack={onBack}
+          onDelete={() => {
+            setPage("confirm-delete");
+          }}
+        />
       );
 
     case "confirm-delete":
       return (
-        <ConfirmDeletePostPage
+        <ConfirmDeletePage
           id={id}
           adminSecret={adminSecret}
           onCancel={() => {

--- a/app/src/admin/posts/SubmitPostForm.tsx
+++ b/app/src/admin/posts/SubmitPostForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { parseAdminSubmitPost, type AdminSubmitPostInput } from "shared";
 import { useAdminUsers } from "../hooks";
 
@@ -19,6 +19,10 @@ const AuthorOptions: React.FC<AuthorOptionsProps> = ({ adminSecret }) => {
 
 export interface SubmitPostFormProps {
   adminSecret: string;
+  initialAuthorId?: number;
+  initialTimestamp?: number;
+  initialCaption?: string;
+  initialReactions?: number;
   disabled: boolean;
   onSubmit: (post: AdminSubmitPostInput) => void;
   children: React.ReactNode;
@@ -26,14 +30,52 @@ export interface SubmitPostFormProps {
 
 export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
   adminSecret,
+  initialAuthorId,
+  initialTimestamp,
+  initialCaption,
+  initialReactions,
   disabled,
   onSubmit,
   children,
 }) => {
-  const [authorId, setAuthorId] = useState(-1);
-  const [timestamp, setTimestamp] = useState(-1);
-  const [caption, setCaption] = useState("");
-  const [reactions, setReactions] = useState(0);
+  const authorIdRef = useRef<HTMLSelectElement>(null);
+  const timestampRef = useRef<HTMLInputElement>(null);
+  const captionRef = useRef<HTMLTextAreaElement>(null);
+  const reactionsRef = useRef<HTMLInputElement>(null);
+
+  const [authorId, setAuthorId] = useState(initialAuthorId ?? -1);
+  const [timestamp, setTimestamp] = useState(initialTimestamp ?? -1);
+  const [caption, setCaption] = useState(initialCaption ?? "");
+  const [reactions, setReactions] = useState(initialReactions ?? 0);
+
+  useEffect(() => {
+    if (authorIdRef.current && initialAuthorId !== undefined) {
+      authorIdRef.current.value = initialAuthorId.toFixed();
+      setAuthorId(initialAuthorId);
+    }
+  }, [authorIdRef, initialAuthorId]);
+
+  useEffect(() => {
+    if (timestampRef.current && initialTimestamp !== undefined) {
+      const date = new Date(initialTimestamp * 1000);
+      timestampRef.current.value = date.toISOString().split("T")[0];
+      setTimestamp(initialTimestamp);
+    }
+  }, [timestampRef, initialTimestamp]);
+
+  useEffect(() => {
+    if (captionRef.current && initialCaption !== undefined) {
+      captionRef.current.value = initialCaption;
+      setCaption(initialCaption);
+    }
+  }, [captionRef, initialCaption]);
+
+  useEffect(() => {
+    if (reactionsRef.current && initialReactions !== undefined) {
+      reactionsRef.current.value = initialReactions.toFixed();
+      setReactions(initialReactions);
+    }
+  }, [reactionsRef, initialReactions]);
 
   const post = useMemo(() => {
     try {
@@ -53,6 +95,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
     <>
       <select
         className="admin-input"
+        ref={authorIdRef}
         defaultValue={-1}
         disabled={disabled}
         onChange={(e) => {
@@ -67,6 +110,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
       <input
         className="admin-input"
         type="date"
+        ref={timestampRef}
         disabled={disabled}
         onChange={(e) => {
           if (e.target.valueAsDate) {
@@ -80,6 +124,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
       <textarea
         className="admin-input"
         placeholder="Caption"
+        ref={captionRef}
         disabled={disabled}
         onChange={(e) => {
           setCaption(e.target.value);
@@ -90,6 +135,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
         type="number"
         placeholder="Reactions"
         inputMode="numeric"
+        ref={reactionsRef}
         disabled={disabled}
         onChange={(e) => {
           setReactions(e.target.valueAsNumber);

--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -4,8 +4,8 @@ import httpErrors from "http-errors";
 import {
   AdminPostsInput,
   AdminUsersInput,
-  parseAdminSubmitPost,
   parseAdminPosts,
+  parseAdminSubmitPost,
   parseAdminUsers,
 } from "shared";
 
@@ -64,6 +64,24 @@ export default function adminApiRoute(fastify: FastifyInstance) {
         media_type: null,
         reactions: post.reactions,
       })
+      .execute();
+  });
+
+  fastify.put<{
+    Params: { id: number };
+  }>("/api/admin/posts/:id", async (request) => {
+    assertAdminSecret(request);
+    const { id } = request.params;
+    const post = parseAdminSubmitPost(request.body);
+    await db
+      .updateTable("posts")
+      .set({
+        author_id: post.authorId,
+        timestamp: post.timestamp,
+        caption: post.caption,
+        reactions: post.reactions,
+      })
+      .where("id", "=", id)
       .execute();
   });
 

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -32,6 +32,21 @@ export function parseAdminPosts(input: unknown) {
   return v.parse(adminPostsSchema, input);
 }
 
+const adminPostDetailsSchema = v.object({
+  id: positiveInteger,
+  authorId: positiveInteger,
+  timestamp: positiveInteger,
+  caption: trimmedString,
+  mediaType: v.nullable(v.union([v.literal("video"), v.literal("image")])),
+  reactions: positiveInteger,
+});
+
+export type AdminPostDetailsInput = v.InferInput<typeof adminPostDetailsSchema>;
+
+export function parseAdminPostDetails(input: unknown) {
+  return v.parse(adminPostDetailsSchema, input);
+}
+
 const adminSubmitPostSchema = v.object({
   authorId: positiveInteger,
   timestamp: positiveInteger,


### PR DESCRIPTION
This pull request resolves #124 by modifying the post details page to include a new update post form. This change also adds several new routes in the backend server for fetching post details and updating posts.