### PR TITLE
Modify Post Caption Type to Never Be Null

### DIFF
--- a/app/src/admin/posts/CreatePostPage.tsx
+++ b/app/src/admin/posts/CreatePostPage.tsx
@@ -83,7 +83,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
         className="admin-input"
         placeholder="Caption"
         onChange={(e) => {
-          setCaption(e.target.value);
+          setCaption(e.target.value.trim());
         }}
       ></textarea>
       <input

--- a/app/src/admin/posts/PostsPage.tsx
+++ b/app/src/admin/posts/PostsPage.tsx
@@ -32,27 +32,30 @@ const PostCards: React.FC<PostCardsProps> = ({ adminSecret, onPostClick }) => {
 
   return (
     <>
-      {posts.map((post) => (
-        <div
-          key={post.id}
-          className="admin-card"
-          onClick={() => {
-            onPostClick(post.id);
-          }}
-        >
-          ID: {post.id}
-          <br />
-          Author: {post.authorName}
-          <br />
-          Date: {new Date(post.timestamp * 1000).toLocaleDateString()}
-          <br />
-          Caption: {post.caption ?? "_"}
-          <br />
-          Media Type: {post.mediaType ?? "_"}
-          <br />
-          Reactions: {post.reactions}
-        </div>
-      ))}
+      {posts.map((post) => {
+        const trimmedCaption = post.caption.trim();
+        return (
+          <div
+            key={post.id}
+            className="admin-card"
+            onClick={() => {
+              onPostClick(post.id);
+            }}
+          >
+            ID: {post.id}
+            <br />
+            Author: {post.authorName}
+            <br />
+            Date: {new Date(post.timestamp * 1000).toLocaleDateString()}
+            <br />
+            Caption: {trimmedCaption !== "" ? trimmedCaption : "_"}
+            <br />
+            Media Type: {post.mediaType ?? "_"}
+            <br />
+            Reactions: {post.reactions}
+          </div>
+        );
+      })}
     </>
   );
 };

--- a/app/src/timeline/post/Post.tsx
+++ b/app/src/timeline/post/Post.tsx
@@ -46,6 +46,7 @@ function formatDate(timestamp: number): string {
 const Post: React.FC<PostProps> = ({ post }) => {
   const [isLiked, setIsLiked] = useState(false);
 
+  const trimmedCaption = post.caption.trim();
   const reactions = post.reactions + (isLiked ? 1 : 0);
 
   const onLikeClicked = () => {
@@ -79,14 +80,14 @@ const Post: React.FC<PostProps> = ({ post }) => {
           </button>
         </div>
       </div>
-      {post.caption && (
+      {trimmedCaption !== "" && (
         <div
           className="post-caption"
           style={{
             marginBottom: !post.mediaType && reactions > 0 ? "2px" : "12px",
           }}
         >
-          {post.caption}
+          {trimmedCaption}
         </div>
       )}
       {post.mediaType && (

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -9,6 +9,6 @@ CREATE TABLE posts (
   timestamp INTEGER NOT NULL,
   caption TEXT NOT NULL DEFAULT "",
   media_type TEXT,
-  reactions INTEGER DEFAULT 0,
+  reactions INTEGER NOT NULL DEFAULT 0,
   FOREIGN KEY (author_id) REFERENCES users(id)
 );

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   author_id INTEGER NOT NULL,
   timestamp INTEGER NOT NULL,
-  caption TEXT,
+  caption TEXT NOT NULL DEFAULT "",
   media_type TEXT,
   reactions INTEGER DEFAULT 0,
   FOREIGN KEY (author_id) REFERENCES users(id)

--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -51,7 +51,7 @@ export default function adminApiRoute(fastify: FastifyInstance) {
       .values({
         author_id: post.authorId,
         timestamp: post.timestamp,
-        caption: post.caption,
+        caption: post.caption.trim(),
         media_type: null,
         reactions: post.reactions,
       })

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -10,7 +10,7 @@ interface Database {
     id: Generated<number>;
     author_id: number;
     timestamp: number;
-    caption: string | null;
+    caption: Generated<string>;
     media_type: "image" | "video" | null;
     reactions: Generated<number>;
   };

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -17,7 +17,7 @@ const rawPostSchema = v.object({
   id: v.number(),
   authorName: v.string(),
   timestamp: v.number(),
-  caption: v.nullable(v.string()),
+  caption: v.string(),
   mediaType: v.nullable(v.union([v.literal("video"), v.literal("image")])),
   reactions: v.number(),
 });

--- a/shared/src/schemas/posts.ts
+++ b/shared/src/schemas/posts.ts
@@ -7,7 +7,7 @@ const postSchema = v.object({
     name: v.string(),
   }),
   timestamp: v.number(),
-  caption: v.nullable(v.string()),
+  caption: v.string(),
   mediaType: v.nullable(v.union([v.literal("video"), v.literal("image")])),
   reactions: v.number(),
 });


### PR DESCRIPTION
This pull request resolves #126 by modifying the post caption and reactions types to never be null. This change also ensures that the caption is always stored and displayed in trimmed form.