### PR TITLE
Modify Admin Post Creation to Return After Post Is Created

### DIFF
--- a/app/src/admin/posts/CreatePostPage.tsx
+++ b/app/src/admin/posts/CreatePostPage.tsx
@@ -45,6 +45,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
         body: JSON.stringify(post),
       });
       if (!res.ok) throw new Error(res.statusText);
+      onBack();
     } catch (err) {
       console.error("Failed to create post:", err);
     } finally {


### PR DESCRIPTION
This pull request resolves #130 by modifying the admin create post page to return after a post is successfully created.