### PR TITLE
Type Schema Inputs Before Parsing

### DIFF
--- a/app/src/admin/hooks.ts
+++ b/app/src/admin/hooks.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { parseAdminUsersSchema } from "shared";
+import { parseAdminUsers } from "shared";
 
 export function useAdminUsers(adminSecret: string) {
   const { data } = useQuery({
@@ -10,7 +10,7 @@ export function useAdminUsers(adminSecret: string) {
           headers: { "admin-secret": adminSecret },
         });
         if (!res.ok) throw new Error(res.statusText);
-        return parseAdminUsersSchema(await res.json());
+        return parseAdminUsers(await res.json());
       } catch (err) {
         console.error("Failed to fetch users:", err);
         throw err;

--- a/app/src/admin/posts/CreatePostPage.tsx
+++ b/app/src/admin/posts/CreatePostPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { parseAdminCreatePostSchema } from "shared";
+import { parseAdminCreatePost, type AdminCreatePostInput } from "shared";
 import { useAdminUsers } from "../hooks";
 
 export interface CreatePostPageProps {
@@ -22,12 +22,13 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
 
   const post = useMemo(() => {
     try {
-      return parseAdminCreatePostSchema({
+      const input: AdminCreatePostInput = {
         authorId,
         timestamp,
         caption,
         reactions,
-      });
+      };
+      return parseAdminCreatePost(input);
     } catch {
       return null;
     }

--- a/app/src/admin/posts/PostsPage.tsx
+++ b/app/src/admin/posts/PostsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
-import { parseAdminPostSchema } from "shared";
+import { parseAdminPosts } from "shared";
 import CreatePostPage from "./CreatePostPage";
 import EditPostPage from "./EditPostPage";
 
@@ -20,7 +20,7 @@ const PostCards: React.FC<PostCardsProps> = ({ adminSecret, onPostClick }) => {
           headers: { "admin-secret": adminSecret },
         });
         if (!res.ok) throw new Error(res.statusText);
-        const posts = parseAdminPostSchema(await res.json());
+        const posts = parseAdminPosts(await res.json());
         return posts.sort((a, b) => a.timestamp - b.timestamp);
       } catch (err) {
         console.error("Failed to fetch posts:", err);

--- a/app/src/timeline/Timeline.tsx
+++ b/app/src/timeline/Timeline.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
-import { parsePostsSchema } from "shared";
+import { parsePosts } from "shared";
 import Post from "./post/Post";
 
 interface TimeLineProps {
@@ -17,7 +17,7 @@ const Timeline: React.FC<TimeLineProps> = ({
     queryFn: async () => {
       const res = await fetch("/api/posts");
       if (!res.ok) throw new Error(res.statusText);
-      const posts = parsePostsSchema(await res.json());
+      const posts = parsePosts(await res.json());
       return posts.sort((a, b) => a.timestamp - b.timestamp);
     },
     initialData: [],

--- a/app/src/timeline/post/Post.tsx
+++ b/app/src/timeline/post/Post.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import type { PostSchema } from "shared";
+import type { PostOutput } from "shared";
 import defaultAvatar from "./assets/default-avatar.webp";
 import CommentIcon from "./assets/comment-icon.png";
 import LikeIcon from "./assets/like-icon.png";
@@ -14,7 +14,7 @@ import PostMedia from "./PostMedia";
 import "./Post.css";
 
 export interface PostProps {
-  post: PostSchema;
+  post: PostOutput;
 }
 
 const monthNames = [

--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -2,9 +2,11 @@ import { FastifyInstance, FastifyRequest } from "fastify";
 import httpErrors from "http-errors";
 
 import {
-  parseAdminCreatePostSchema,
-  parseAdminPostSchema,
-  parseAdminUsersSchema,
+  AdminPostsInput,
+  AdminUsersInput,
+  parseAdminCreatePost,
+  parseAdminPosts,
+  parseAdminUsers,
 } from "shared";
 
 import { db } from "../db.js";
@@ -24,17 +26,17 @@ export default function adminApiRoute(fastify: FastifyInstance) {
 
   fastify.get("/api/admin/users", async (request) => {
     assertAdminSecret(request);
-    const rows = await db
+    const rows: AdminUsersInput = await db
       .selectFrom("users")
       .select(["id", "name", "has_avatar as hasAvatar"])
       .execute();
 
-    return parseAdminUsersSchema(rows);
+    return parseAdminUsers(rows);
   });
 
   fastify.get("/api/admin/posts", async (request) => {
     assertAdminSecret(request);
-    const rows = await db
+    const rows: AdminPostsInput = await db
       .selectFrom("posts")
       .innerJoin("users", "posts.author_id", "users.id")
       .select([
@@ -47,12 +49,12 @@ export default function adminApiRoute(fastify: FastifyInstance) {
       ])
       .execute();
 
-    return parseAdminPostSchema(rows);
+    return parseAdminPosts(rows);
   });
 
   fastify.post("/api/admin/posts", async (request) => {
     assertAdminSecret(request);
-    const post = parseAdminCreatePostSchema(request.body);
+    const post = parseAdminCreatePost(request.body);
     await db
       .insertInto("posts")
       .values({

--- a/server/src/api/posts.ts
+++ b/server/src/api/posts.ts
@@ -1,10 +1,10 @@
 import { FastifyInstance } from "fastify";
-import { parsePostsSchema } from "shared";
+import { parsePosts, PostsInput } from "shared";
 import { db } from "../db.js";
 
 export default function postsApiRoute(fastify: FastifyInstance) {
   fastify.get("/api/posts", async () => {
-    const rows = await db
+    const rows: PostsInput = await db
       .selectFrom("posts")
       .innerJoin("users", "posts.author_id", "users.id")
       .select([
@@ -19,6 +19,6 @@ export default function postsApiRoute(fastify: FastifyInstance) {
       ])
       .execute();
 
-    return parsePostsSchema(rows);
+    return parsePosts(rows);
   });
 }

--- a/shared/src/schemas/admin.ts
+++ b/shared/src/schemas/admin.ts
@@ -1,35 +1,35 @@
 import * as v from "valibot";
 import { integerToBoolean, positiveInteger, trimmedString } from "./types.js";
 
-const adminUserSchema = v.object({
-  id: positiveInteger,
-  name: trimmedString,
-  hasAvatar: integerToBoolean,
-});
+const adminUsersSchema = v.array(
+  v.object({
+    id: positiveInteger,
+    name: trimmedString,
+    hasAvatar: integerToBoolean,
+  }),
+);
 
-const adminUsersSchema = v.array(adminUserSchema);
+export type AdminUsersInput = v.InferInput<typeof adminUsersSchema>;
 
-export type AdminUserSchema = v.InferInput<typeof adminUserSchema>;
-
-export function parseAdminUsersSchema(data: unknown) {
-  return v.parse(adminUsersSchema, data);
+export function parseAdminUsers(input: unknown) {
+  return v.parse(adminUsersSchema, input);
 }
 
-const adminPostSchema = v.object({
-  id: positiveInteger,
-  authorName: trimmedString,
-  timestamp: positiveInteger,
-  caption: trimmedString,
-  mediaType: v.nullable(v.union([v.literal("video"), v.literal("image")])),
-  reactions: positiveInteger,
-});
+const adminPostsSchema = v.array(
+  v.object({
+    id: positiveInteger,
+    authorName: trimmedString,
+    timestamp: positiveInteger,
+    caption: trimmedString,
+    mediaType: v.nullable(v.union([v.literal("video"), v.literal("image")])),
+    reactions: positiveInteger,
+  }),
+);
 
-const adminPostsSchema = v.array(adminPostSchema);
+export type AdminPostsInput = v.InferInput<typeof adminPostsSchema>;
 
-export type AdminPostSchema = v.InferInput<typeof adminPostSchema>;
-
-export function parseAdminPostSchema(data: unknown) {
-  return v.parse(adminPostsSchema, data);
+export function parseAdminPosts(input: unknown) {
+  return v.parse(adminPostsSchema, input);
 }
 
 const adminCreatePostSchema = v.object({
@@ -39,8 +39,8 @@ const adminCreatePostSchema = v.object({
   reactions: positiveInteger,
 });
 
-export type AdminCreatePostSchema = v.InferInput<typeof adminCreatePostSchema>;
+export type AdminCreatePostInput = v.InferInput<typeof adminCreatePostSchema>;
 
-export function parseAdminCreatePostSchema(data: unknown) {
-  return v.parse(adminCreatePostSchema, data);
+export function parseAdminCreatePost(input: unknown) {
+  return v.parse(adminCreatePostSchema, input);
 }

--- a/shared/src/schemas/posts.ts
+++ b/shared/src/schemas/posts.ts
@@ -12,10 +12,12 @@ const postSchema = v.object({
   reactions: positiveInteger,
 });
 
+export type PostOutput = v.InferOutput<typeof postSchema>;
+
 const postsSchema = v.array(postSchema);
 
-export type PostSchema = v.InferInput<typeof postSchema>;
+export type PostsInput = v.InferInput<typeof postsSchema>;
 
-export function parsePostsSchema(data: unknown) {
-  return v.parse(postsSchema, data);
+export function parsePosts(input: unknown) {
+  return v.parse(postsSchema, input);
 }


### PR DESCRIPTION
This pull request resolves #134 by improving the code in this project through the addition of type hints to schema inputs before parsing, when the input types are known. This change also includes renaming types and functions in the `schema` package.