### PR TITLE
Disable Inputs and Buttons During Post Creation and Deletion in Admin Page

### DIFF
--- a/app/src/admin/AdminDashboard.css
+++ b/app/src/admin/AdminDashboard.css
@@ -17,7 +17,7 @@
 }
 
 .admin-button:disabled {
-  cursor: not-allowed;
+  cursor: auto;
   color: gray;
 }
 
@@ -33,6 +33,10 @@
   font-size: 14px;
 }
 
+.admin-input:disabled {
+  color: gray;
+}
+
 .admin-input:focus {
   outline: none;
 }
@@ -44,6 +48,10 @@
 textarea.admin-input {
   min-height: 80px;
   resize: vertical;
+}
+
+textarea.admin-input:disabled {
+  resize: none;
 }
 
 .admin-card {

--- a/app/src/admin/posts/CreatePostPage.tsx
+++ b/app/src/admin/posts/CreatePostPage.tsx
@@ -57,12 +57,13 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
   return (
     <>
       <h1 className="admin-title">Create Post</h1>
-      <button className="admin-button" onClick={onBack}>
+      <button className="admin-button" disabled={isCreating} onClick={onBack}>
         Back
       </button>
       <select
         className="admin-input"
         defaultValue={-1}
+        disabled={isCreating}
         onChange={(e) => {
           setAuthorId(parseInt(e.target.value));
         }}
@@ -79,6 +80,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
       <input
         className="admin-input"
         type="date"
+        disabled={isCreating}
         onChange={(e) => {
           if (e.target.valueAsDate) {
             const milliseconds = e.target.valueAsDate.getTime();
@@ -91,6 +93,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
       <textarea
         className="admin-input"
         placeholder="Caption"
+        disabled={isCreating}
         onChange={(e) => {
           setCaption(e.target.value);
         }}
@@ -100,6 +103,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
         type="number"
         placeholder="Reactions"
         inputMode="numeric"
+        disabled={isCreating}
         onChange={(e) => {
           setReactions(e.target.valueAsNumber);
         }}

--- a/app/src/admin/posts/EditPostPage.tsx
+++ b/app/src/admin/posts/EditPostPage.tsx
@@ -34,10 +34,14 @@ const ConfirmDeletePostPage: React.FC<ConfirmDeletePostPageProps> = ({
   return (
     <>
       <h1 className="admin-title">Confirm Delete Post {id}</h1>
-      <button className="admin-button" onClick={() => void deletePost()}>
+      <button
+        className="admin-button"
+        disabled={isDeleting}
+        onClick={() => void deletePost()}
+      >
         {isDeleting ? "Deleting Post..." : "Delete Post"}
       </button>
-      <button className="admin-button" onClick={onCancel}>
+      <button className="admin-button" disabled={isDeleting} onClick={onCancel}>
         Cancel
       </button>
     </>


### PR DESCRIPTION
This pull request resolves #136 by modifying the admin page to disable inputs and buttons during post creation and deletion.