### PR TITLE
Generalize Page Logic in Admin Dashboard

### DIFF
--- a/app/src/admin/posts/PostDetailsPage.tsx
+++ b/app/src/admin/posts/PostDetailsPage.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+type Page = "main" | "confirm-delete";
+
 export interface ConfirmDeletePostPageProps {
   id: number;
   adminSecret: string;
@@ -59,33 +61,39 @@ const PostDetailsPage: React.FC<PostDetailsPageProps> = ({
   adminSecret,
   onBack,
 }) => {
-  const [isConfirmDelete, setIsConfirmDelete] = useState(false);
+  const [page, setPage] = useState<Page>("main");
 
-  return isConfirmDelete ? (
-    <ConfirmDeletePostPage
-      id={id}
-      adminSecret={adminSecret}
-      onCancel={() => {
-        setIsConfirmDelete(false);
-      }}
-      onDelete={onBack}
-    />
-  ) : (
-    <>
-      <h1 className="admin-title">Post {id}</h1>
-      <button className="admin-button" onClick={onBack}>
-        Back
-      </button>
-      <button
-        className="admin-button"
-        onClick={() => {
-          setIsConfirmDelete(true);
-        }}
-      >
-        Delete Post
-      </button>
-    </>
-  );
+  switch (page) {
+    case "main":
+      return (
+        <>
+          <h1 className="admin-title">Post {id}</h1>
+          <button className="admin-button" onClick={onBack}>
+            Back
+          </button>
+          <button
+            className="admin-button"
+            onClick={() => {
+              setPage("confirm-delete");
+            }}
+          >
+            Delete Post
+          </button>
+        </>
+      );
+
+    case "confirm-delete":
+      return (
+        <ConfirmDeletePostPage
+          id={id}
+          adminSecret={adminSecret}
+          onCancel={() => {
+            setPage("main");
+          }}
+          onDelete={onBack}
+        />
+      );
+  }
 };
 
 export default PostDetailsPage;

--- a/app/src/admin/posts/PostDetailsPage.tsx
+++ b/app/src/admin/posts/PostDetailsPage.tsx
@@ -48,13 +48,13 @@ const ConfirmDeletePostPage: React.FC<ConfirmDeletePostPageProps> = ({
   );
 };
 
-export interface EditPostPageProps {
+export interface PostDetailsPageProps {
   id: number;
   adminSecret: string;
   onBack: () => void;
 }
 
-const EditPostPage: React.FC<EditPostPageProps> = ({
+const PostDetailsPage: React.FC<PostDetailsPageProps> = ({
   id,
   adminSecret,
   onBack,
@@ -72,7 +72,7 @@ const EditPostPage: React.FC<EditPostPageProps> = ({
     />
   ) : (
     <>
-      <h1 className="admin-title">Edit Post {id}</h1>
+      <h1 className="admin-title">Post {id}</h1>
       <button className="admin-button" onClick={onBack}>
         Back
       </button>
@@ -88,4 +88,4 @@ const EditPostPage: React.FC<EditPostPageProps> = ({
   );
 };
 
-export default EditPostPage;
+export default PostDetailsPage;

--- a/app/src/admin/posts/PostsPage.tsx
+++ b/app/src/admin/posts/PostsPage.tsx
@@ -4,7 +4,7 @@ import { parseAdminPosts } from "shared";
 import CreatePostPage from "./CreatePostPage";
 import EditPostPage from "./EditPostPage";
 
-type Page = "main" | "create" | "edit";
+type Page = "main" | "create" | number;
 
 interface PostCardsProps {
   adminSecret: string;
@@ -64,7 +64,6 @@ export interface PostsPageProps {
 
 const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
   const [page, setPage] = useState<Page>("main");
-  const [selectedId, setSelectedId] = useState(-1);
 
   switch (page) {
     case "main":
@@ -85,8 +84,7 @@ const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
           <PostCards
             adminSecret={adminSecret}
             onPostClick={(id) => {
-              setSelectedId(id);
-              setPage("edit");
+              setPage(id);
             }}
           />
         </>
@@ -102,10 +100,10 @@ const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
         />
       );
 
-    case "edit":
+    default:
       return (
         <EditPostPage
-          id={selectedId}
+          id={page}
           adminSecret={adminSecret}
           onBack={() => {
             setPage("main");

--- a/app/src/admin/posts/PostsPage.tsx
+++ b/app/src/admin/posts/PostsPage.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { parseAdminPosts } from "shared";
 import CreatePostPage from "./CreatePostPage";
-import EditPostPage from "./EditPostPage";
+import PostDetailsPage from "./PostDetailsPage";
 
 type Page = "main" | "create" | number;
 
@@ -102,7 +102,7 @@ const PostsPage: React.FC<PostsPageProps> = ({ adminSecret, onBack }) => {
 
     default:
       return (
-        <EditPostPage
+        <PostDetailsPage
           id={page}
           adminSecret={adminSecret}
           onBack={() => {


### PR DESCRIPTION
This pull request resolves #140 by generalizing the page logic in the admin dashboard to consistently use a unified `page` state. This change also renames the `EditPostPage` component to `PostDetailsPage`.