### PR TITLE
Add Labels to Form Inputs in Admin Create and Post Details Pages

### DIFF
--- a/app/src/admin/AdminDashboard.css
+++ b/app/src/admin/AdminDashboard.css
@@ -21,6 +21,13 @@
   color: gray;
 }
 
+.admin-input-label {
+  margin: 0 10px;
+  color: black;
+  font-size: 12px;
+  text-align: left;
+}
+
 .admin-input {
   box-sizing: border-box;
   margin: 0 4px;

--- a/app/src/admin/posts/SubmitPostForm.tsx
+++ b/app/src/admin/posts/SubmitPostForm.tsx
@@ -93,6 +93,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
 
   return (
     <>
+      <label className="admin-input-label">Author</label>
       <select
         className="admin-input"
         ref={authorIdRef}
@@ -107,6 +108,7 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
         </option>
         <AuthorOptions adminSecret={adminSecret} />
       </select>
+      <label className="admin-input-label">Date</label>
       <input
         className="admin-input"
         type="date"
@@ -121,19 +123,20 @@ export const SubmitPostForm: React.FC<SubmitPostFormProps> = ({
           }
         }}
       />
+      <label className="admin-input-label">Caption</label>
       <textarea
         className="admin-input"
-        placeholder="Caption"
         ref={captionRef}
         disabled={disabled}
         onChange={(e) => {
           setCaption(e.target.value);
         }}
-      ></textarea>
+      />
+      <label className="admin-input-label">Reactions</label>
       <input
         className="admin-input"
         type="number"
-        placeholder="Reactions"
+        placeholder="0"
         inputMode="numeric"
         ref={reactionsRef}
         disabled={disabled}


### PR DESCRIPTION
This pull request resolves #144 by adding labels to the form inputs in the admin create post and post details pages.