### PR TITLE
Modify Admin Button to Display Error on Error

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.83.0",
+    "catched-error-message": "^0.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-intersection-observer": "^9.16.0",

--- a/app/src/admin/posts/CreatePostPage.tsx
+++ b/app/src/admin/posts/CreatePostPage.tsx
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "catched-error-message";
 import React, { useState } from "react";
 import { parseAdminCreatetPostResult } from "shared";
 import { useParseAdminSubmitPost } from "../hooks";
@@ -17,6 +18,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
   onBack,
 }) => {
   const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<unknown>(null);
 
   const { post, setAuthorId, setTimestamp, setCaption, setReactions } =
     useParseAdminSubmitPost();
@@ -25,6 +27,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
 
   const createPost = async () => {
     setIsCreating(true);
+    setError(null);
     try {
       const res = await fetch("/api/admin/posts", {
         method: "POST",
@@ -52,6 +55,7 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
       onBack();
     } catch (err) {
       console.error("Failed to create post:", err);
+      setError(err);
     } finally {
       setIsCreating(false);
     }
@@ -107,8 +111,17 @@ const CreatePostPage: React.FC<CreatePostPageProps> = ({
           void createPost();
         }}
       >
-        {isCreating ? "Creating Post..." : "Create Post"}
+        {isCreating
+          ? "Creating Post..."
+          : error
+            ? "Failed to Create Post"
+            : "Create Post"}
       </button>
+      {error && (
+        <label className="admin-input-label">
+          Error: {getErrorMessage(error)}
+        </label>
+      )}
     </>
   );
 };

--- a/app/src/admin/posts/PostDetailsPage.tsx
+++ b/app/src/admin/posts/PostDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { getErrorMessage } from "catched-error-message";
 import React, { useState } from "react";
 import { parseAdminPostDetails } from "shared";
 import { useParseAdminSubmitPost } from "../hooks";
@@ -23,6 +24,7 @@ const MainPage: React.FC<MainPageProps> = ({
   onDelete,
 }) => {
   const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<unknown>(null);
 
   const { data: postDetails } = useQuery({
     queryKey: ["admin/posts", id, adminSecret],
@@ -46,6 +48,7 @@ const MainPage: React.FC<MainPageProps> = ({
 
   const updatePost = async () => {
     setIsUpdating(true);
+    setError(null);
     try {
       const res = await fetch(`/api/admin/posts/${id.toFixed()}`, {
         method: "PUT",
@@ -58,6 +61,7 @@ const MainPage: React.FC<MainPageProps> = ({
       if (!res.ok) throw new Error(res.statusText);
     } catch (err) {
       console.error("Failed to update post:", err);
+      setError(err);
     } finally {
       setIsUpdating(false);
     }
@@ -109,8 +113,17 @@ const MainPage: React.FC<MainPageProps> = ({
           void updatePost();
         }}
       >
-        {isUpdating ? "Updating Post..." : "Update Post"}
+        {isUpdating
+          ? "Updating Post..."
+          : error
+            ? "Failed to Update Post"
+            : "Update Post"}
       </button>
+      {error && (
+        <label className="admin-input-label">
+          Error: {getErrorMessage(error)}
+        </label>
+      )}
       <button
         className="admin-button"
         disabled={!postDetails || isUpdating}
@@ -136,9 +149,11 @@ const ConfirmDeletePage: React.FC<ConfirmDeletePageProps> = ({
   onDelete,
 }) => {
   const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<unknown>(null);
 
   const deletePost = async () => {
     setIsDeleting(true);
+    setError(null);
     try {
       const res = await fetch(`/api/admin/posts/${id.toFixed()}`, {
         method: "DELETE",
@@ -148,6 +163,7 @@ const ConfirmDeletePage: React.FC<ConfirmDeletePageProps> = ({
       onDelete();
     } catch (err) {
       console.error(`Failed to delete post ${id.toString()}:`, err);
+      setError(err);
     } finally {
       setIsDeleting(false);
     }
@@ -161,8 +177,17 @@ const ConfirmDeletePage: React.FC<ConfirmDeletePageProps> = ({
         disabled={isDeleting}
         onClick={() => void deletePost()}
       >
-        {isDeleting ? "Deleting Post..." : "Delete Post"}
+        {isDeleting
+          ? "Deleting Post..."
+          : error
+            ? "Failed to Delete Post"
+            : "Delete Post"}
       </button>
+      {error && (
+        <label className="admin-input-label">
+          Error: {getErrorMessage(error)}
+        </label>
+      )}
       <button className="admin-button" disabled={isDeleting} onClick={onCancel}>
         Cancel
       </button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.83.0
         version: 5.83.0(react@19.1.0)
+      catched-error-message:
+        specifier: ^0.0.1
+        version: 0.0.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1016,6 +1019,9 @@ packages:
 
   caniuse-lite@1.0.30001724:
     resolution: {integrity: sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==}
+
+  catched-error-message@0.0.1:
+    resolution: {integrity: sha512-Nml8YxCdXMIdACzCasyG3GmQZob15IjQNMWPAEyqQLsyrQYBLaYq8cZWccMdpodnAsGu48E0DQxoUpR6hWVFZg==}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -3386,6 +3392,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001724: {}
+
+  catched-error-message@0.0.1: {}
 
   chai@5.2.0:
     dependencies:


### PR DESCRIPTION
This pull request resolves #149 by modifying the admin create, update, and delete post buttons to display an error message when an error occurs.