### PR TITLE
Fix Image Orientation When Creating Post Image Media

### DIFF
--- a/server/src/api/admin.ts
+++ b/server/src/api/admin.ts
@@ -157,6 +157,7 @@ export default function adminApiRoute(fastify: FastifyInstance) {
     const webpFile = `data/static/posts/medias/${id}/390.webp`;
     const magick = spawn("magick", [
       oriFile,
+      "-auto-orient",
       "-resize",
       "1170x",
       "-filter",


### PR DESCRIPTION
This pull request fixes #161 by adding `-auto-orient` option when calling the ImageMagick for converting images.