### PR TITLE
Configure File Limit Accepted by Backend Server

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,12 @@ import { apiPostsRoute } from "./apis/apiPosts.js";
 
 const fastify = Fastify({ logger: true });
 
-fastify.register(fastifyMultipart);
+fastify.register(fastifyMultipart, {
+  limits: {
+    fileSize: Infinity,
+    files: 1,
+  },
+});
 
 if (process.env.ADMIN_SECRET) {
   fastify.register(apiAdminRoute);


### PR DESCRIPTION
This pull request resolves #177 by configuring the backend server to accept a maximum of one file with unlimited upload size.