### PR TITLE
Add Support for Deleting Users in Admin Dashboard

### DIFF
--- a/server/src/apis/apiAdminUsersId.ts
+++ b/server/src/apis/apiAdminUsersId.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import { rm } from "node:fs/promises";
 
 import {
   AdminUserDetailsInput,
@@ -35,5 +36,19 @@ export function apiAdminUsersIdRoute(fastify: FastifyInstance) {
       .set({ name: post.name })
       .where("id", "=", id)
       .execute();
+  });
+
+  fastify.delete<{
+    Params: { id: string };
+  }>("/api/admin/users/:id", async (request) => {
+    assertAdminSecret(request);
+    const { id } = request.params;
+
+    await rm(`data/static/users/avatars/${id}`, {
+      recursive: true,
+      force: true,
+    });
+
+    await db.deleteFrom("users").where("id", "=", id).execute();
   });
 }


### PR DESCRIPTION
This pull request resolves #183 by modifying the `UserDetailsPage` component in the admin dashboard to allow deleting users. In doing so, it also adds a new `DELETE /api/admin/users/:id` route to the backend server.