### PR TITLE
Add Support for Uploading and Removing User Avatars in Admin Dashboard

### DIFF
--- a/app/src/admin/AdminDashboard.css
+++ b/app/src/admin/AdminDashboard.css
@@ -90,3 +90,19 @@ textarea.admin-input:disabled {
   width: 100%;
   object-fit: cover;
 }
+
+.admin-avatar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 4px;
+  border-radius: 8px;
+  background-color: white;
+}
+
+.admin-avatar img {
+  border-radius: 8px;
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+}

--- a/app/src/admin/users/CreateUserPage.tsx
+++ b/app/src/admin/users/CreateUserPage.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
+import { parseAdminCreatetResult } from "shared";
 import { useParseAdminSubmitUser } from "../hooks";
 import ActionButton from "../inputs/ActionButton";
+import FileInput from "../inputs/FileInput";
 import TextInput from "../inputs/TextInput";
 
 export interface CreateUserPageProps {
@@ -13,6 +15,7 @@ const CreateUserPage: React.FC<CreateUserPageProps> = ({
   onBack,
 }) => {
   const { user, setName } = useParseAdminSubmitUser();
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
 
   return (
     <>
@@ -24,6 +27,13 @@ const CreateUserPage: React.FC<CreateUserPageProps> = ({
         label="Name"
         onTextChanged={(text) => {
           setName(text);
+        }}
+      />
+      <FileInput
+        label="Avatar"
+        accept="image/*"
+        onFileChanged={(file) => {
+          setAvatarFile(file);
         }}
       />
       <ActionButton
@@ -41,6 +51,20 @@ const CreateUserPage: React.FC<CreateUserPageProps> = ({
             body: JSON.stringify(user),
           });
           if (!res.ok) throw new Error(res.statusText);
+          const { id } = parseAdminCreatetResult(await res.json());
+
+          if (avatarFile) {
+            const formData = new FormData();
+            formData.append("file", avatarFile);
+
+            const res = await fetch(`/api/admin/users/${id}/avatar`, {
+              method: "POST",
+              headers: { "admin-secret": adminSecret },
+              body: formData,
+            });
+            if (!res.ok) throw new Error(res.statusText);
+          }
+
           onBack();
         }}
       />

--- a/app/src/admin/users/UserDetailsPage.tsx
+++ b/app/src/admin/users/UserDetailsPage.tsx
@@ -2,21 +2,28 @@ import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { parseAdminUserDetails } from "shared";
 import ActionButton from "../inputs/ActionButton";
+import FileInput from "../inputs/FileInput";
 import TextInput from "../inputs/TextInput";
 import { useParseAdminSubmitUser } from "../hooks";
 import { shortenId } from "../utils";
 
-type Page = "main" | "confirm-delete" | "confirm-avatar-delete";
+type Page =
+  | "main"
+  | "confirm-delete"
+  | "create-avatar"
+  | "confirm-avatar-delete";
 
 interface UpdateUserFormProps {
   id: string;
   adminSecret: string;
+  onCreateAvatar: () => void;
   onDeleteAvatar: () => void;
 }
 
 const UpdateUserForm: React.FC<UpdateUserFormProps> = ({
   id,
   adminSecret,
+  onCreateAvatar,
   onDeleteAvatar,
 }) => {
   const { data: userDetails } = useQuery({
@@ -65,17 +72,69 @@ const UpdateUserForm: React.FC<UpdateUserFormProps> = ({
           if (!res.ok) throw new Error(res.statusText);
         }}
       />
-      {userDetails && userDetails.hasAvatar && (
-        <>
-          <label className="admin-input-label">Avatar</label>
-          <div className="admin-avatar">
-            <img src={`/static/users/avatars/${id}/40x40.webp`} />
-          </div>
-          <button className="admin-button" onClick={onDeleteAvatar}>
-            Delete User Avatar
+      {userDetails &&
+        (userDetails.hasAvatar ? (
+          <>
+            <label className="admin-input-label">Avatar</label>
+            <div className="admin-avatar">
+              <img src={`/static/users/avatars/${id}/40x40.webp`} />
+            </div>
+            <button className="admin-button" onClick={onDeleteAvatar}>
+              Delete User Avatar
+            </button>
+          </>
+        ) : (
+          <button className="admin-button" onClick={onCreateAvatar}>
+            Create User Avatar
           </button>
-        </>
-      )}
+        ))}
+    </>
+  );
+};
+
+interface CreateUserAvatarFormProps {
+  id: string;
+  adminSecret: string;
+  onCreated: () => void;
+}
+
+const CreateUserAvatarForm: React.FC<CreateUserAvatarFormProps> = ({
+  id,
+  adminSecret,
+  onCreated,
+}) => {
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+
+  return (
+    <>
+      <FileInput
+        label="Avatar"
+        accept="image/*"
+        onFileChanged={(file) => {
+          setAvatarFile(file);
+        }}
+      />
+      <ActionButton
+        label="Create Usert Avatar"
+        processingLabel="Creating User Avatar..."
+        errorLabel="Failed to Create User Avatar"
+        disabled={!avatarFile}
+        onAction={async () => {
+          if (avatarFile) {
+            const formData = new FormData();
+            formData.append("file", avatarFile);
+
+            const res = await fetch(`/api/admin/users/${id}/avatar`, {
+              method: "POST",
+              headers: { "admin-secret": adminSecret },
+              body: formData,
+            });
+            if (!res.ok) throw new Error(res.statusText);
+
+            onCreated();
+          }
+        }}
+      />
     </>
   );
 };
@@ -104,6 +163,9 @@ const UserDetailsPage: React.FC<UserDetailsPageProps> = ({
           <UpdateUserForm
             id={id}
             adminSecret={adminSecret}
+            onCreateAvatar={() => {
+              setPage("create-avatar");
+            }}
             onDeleteAvatar={() => {
               setPage("confirm-avatar-delete");
             }}
@@ -144,6 +206,28 @@ const UserDetailsPage: React.FC<UserDetailsPageProps> = ({
           >
             Cancel
           </button>
+        </>
+      );
+
+    case "create-avatar":
+      return (
+        <>
+          <h1 className="admin-title">Create User {shortenId(id)} Avatar</h1>
+          <button
+            className="admin-button"
+            onClick={() => {
+              setPage("main");
+            }}
+          >
+            Back
+          </button>
+          <CreateUserAvatarForm
+            id={id}
+            adminSecret={adminSecret}
+            onCreated={() => {
+              setPage("main");
+            }}
+          />
         </>
       );
 

--- a/app/src/admin/users/UserDetailsPage.tsx
+++ b/app/src/admin/users/UserDetailsPage.tsx
@@ -60,6 +60,14 @@ const UpdateUserForm: React.FC<UpdateUserFormProps> = ({ id, adminSecret }) => {
           if (!res.ok) throw new Error(res.statusText);
         }}
       />
+      {userDetails && userDetails.hasAvatar && (
+        <>
+          <label className="admin-input-label">Avatar</label>
+          <div className="admin-avatar">
+            <img src={`/static/users/avatars/${id}/40x40.webp`} />
+          </div>
+        </>
+      )}
     </>
   );
 };

--- a/app/src/admin/users/UserDetailsPage.tsx
+++ b/app/src/admin/users/UserDetailsPage.tsx
@@ -6,14 +6,19 @@ import TextInput from "../inputs/TextInput";
 import { useParseAdminSubmitUser } from "../hooks";
 import { shortenId } from "../utils";
 
-type Page = "main" | "confirm-delete";
+type Page = "main" | "confirm-delete" | "confirm-avatar-delete";
 
 interface UpdateUserFormProps {
   id: string;
   adminSecret: string;
+  onDeleteAvatar: () => void;
 }
 
-const UpdateUserForm: React.FC<UpdateUserFormProps> = ({ id, adminSecret }) => {
+const UpdateUserForm: React.FC<UpdateUserFormProps> = ({
+  id,
+  adminSecret,
+  onDeleteAvatar,
+}) => {
   const { data: userDetails } = useQuery({
     queryKey: ["admin/posts", id, adminSecret],
     queryFn: async () => {
@@ -66,6 +71,9 @@ const UpdateUserForm: React.FC<UpdateUserFormProps> = ({ id, adminSecret }) => {
           <div className="admin-avatar">
             <img src={`/static/users/avatars/${id}/40x40.webp`} />
           </div>
+          <button className="admin-button" onClick={onDeleteAvatar}>
+            Delete User Avatar
+          </button>
         </>
       )}
     </>
@@ -93,7 +101,13 @@ const UserDetailsPage: React.FC<UserDetailsPageProps> = ({
           <button className="admin-button" onClick={onBack}>
             Back
           </button>
-          <UpdateUserForm id={id} adminSecret={adminSecret} />
+          <UpdateUserForm
+            id={id}
+            adminSecret={adminSecret}
+            onDeleteAvatar={() => {
+              setPage("confirm-avatar-delete");
+            }}
+          />
           <button
             className="admin-button"
             onClick={() => {
@@ -120,6 +134,36 @@ const UserDetailsPage: React.FC<UserDetailsPageProps> = ({
               });
               if (!res.ok) throw new Error(res.statusText);
               onBack();
+            }}
+          />
+          <button
+            className="admin-button"
+            onClick={() => {
+              setPage("main");
+            }}
+          >
+            Cancel
+          </button>
+        </>
+      );
+
+    case "confirm-avatar-delete":
+      return (
+        <>
+          <h1 className="admin-title">
+            Confirm Delete User {shortenId(id)} Avatar
+          </h1>
+          <ActionButton
+            label="Delete User Avatar"
+            processingLabel="Deleting User Avatar..."
+            errorLabel="Failed to Delete User Avatar"
+            onAction={async () => {
+              const res = await fetch(`/api/admin/users/${id}/avatar`, {
+                method: "DELETE",
+                headers: { "admin-secret": adminSecret },
+              });
+              if (!res.ok) throw new Error(res.statusText);
+              setPage("main");
             }}
           />
           <button

--- a/server/src/apis/apiAdminUsersIdAvatar.ts
+++ b/server/src/apis/apiAdminUsersIdAvatar.ts
@@ -1,0 +1,55 @@
+import { FastifyInstance } from "fastify";
+import httpErrors from "http-errors";
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { pipeline } from "node:stream";
+import { promisify } from "node:util";
+import { db } from "../db.js";
+import { assertAdminSecret } from "../utils/admin.js";
+import { waitProcess } from "../utils/process.js";
+
+const pump = promisify(pipeline);
+
+export function apiAdminUsersIdAvatarRoute(fastify: FastifyInstance) {
+  fastify.post<{
+    Params: { id: string };
+  }>("/api/admin/users/:id/avatar", async (request) => {
+    assertAdminSecret(request);
+    const { id } = request.params;
+
+    const data = await request.file();
+    if (!data?.mimetype.startsWith("image/")) {
+      throw httpErrors.BadRequest();
+    }
+
+    const ext = path.extname(data.filename);
+    const oriFile = `data/static/users/avatars/${id}/original${ext}`;
+
+    await mkdir(path.dirname(oriFile));
+    await pump(data.file, createWriteStream(oriFile));
+
+    const webpFile = `data/static/users/avatars/${id}/40x40.webp`;
+    const magick = spawn("magick", [
+      oriFile,
+      "-auto-orient",
+      "-resize",
+      "120x120!",
+      "-filter",
+      "Lanczos",
+      "-define",
+      "filter:blur=0.8",
+      "-sharpen",
+      "0x0.8",
+      webpFile,
+    ]);
+    await waitProcess(magick);
+
+    await db
+      .updateTable("users")
+      .set({ has_avatar: 1 })
+      .where("id", "=", id)
+      .execute();
+  });
+}

--- a/server/src/apis/apiAdminUsersIdAvatar.ts
+++ b/server/src/apis/apiAdminUsersIdAvatar.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from "fastify";
 import httpErrors from "http-errors";
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { pipeline } from "node:stream";
 import { promisify } from "node:util";
@@ -49,6 +49,24 @@ export function apiAdminUsersIdAvatarRoute(fastify: FastifyInstance) {
     await db
       .updateTable("users")
       .set({ has_avatar: 1 })
+      .where("id", "=", id)
+      .execute();
+  });
+
+  fastify.delete<{
+    Params: { id: string };
+  }>("/api/admin/users/:id/avatar", async (request) => {
+    assertAdminSecret(request);
+    const { id } = request.params;
+
+    await rm(`data/static/users/avatars/${id}`, {
+      recursive: true,
+      force: true,
+    });
+
+    await db
+      .updateTable("users")
+      .set({ has_avatar: 0 })
       .where("id", "=", id)
       .execute();
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import { apiAdminPostsIdRoute } from "./apis/apiAdminPostsId.js";
 import { apiAdminPostsIdMediaRoute } from "./apis/apiAdminPostsIdMedia.js";
 import { apiAdminUsersRoute } from "./apis/apiAdminUsers.js";
 import { apiAdminUsersIdRoute } from "./apis/apiAdminUsersId.js";
+import { apiAdminUsersIdAvatarRoute } from "./apis/apiAdminUsersIdAvatar.js";
 import { apiPostsRoute } from "./apis/apiPosts.js";
 
 const fastify = Fastify({ logger: true });
@@ -28,6 +29,7 @@ if (process.env.ADMIN_SECRET) {
   fastify.register(apiAdminPostsIdMediaRoute);
   fastify.register(apiAdminUsersRoute);
   fastify.register(apiAdminUsersIdRoute);
+  fastify.register(apiAdminUsersIdAvatarRoute);
 }
 
 fastify.register(apiPostsRoute);


### PR DESCRIPTION
This pull request resolves #185 by modifying the admin dashboard to allow uploading and removing user avatars. In doing so, it also adds several new routes to the backend server.